### PR TITLE
add import os

### DIFF
--- a/run.ipynb
+++ b/run.ipynb
@@ -21,6 +21,8 @@
         "from google.colab import drive\n",
         "drive.mount('/content/drive')\n",
         "\n",
+        "import os\n",
+        "\n",
         "%env PYTHONDONTWRITEBYTECODE=1\n",
         "\n",
         "!apt -y update -qq\n",


### PR DESCRIPTION
```
---> 64 if not os.path.exists(f"/content/drive/MyDrive/stable-diffusion-webui-colab/stable-diffusion-webui/models/CLIP"):
     65   os.mkdir(f"/content/drive/MyDrive/stable-diffusion-webui-colab/stable-diffusion-webui/models/CLIP")
     66 get_ipython().system('aria2c --console-log-level=error -c -x 16 -s 16 -k 1M https://openaipublic.azureedge.net/clip/models/b8cca3fd41ae0c99ba7e8951adf17d267cdb84cd88be6f7c2e0eca1737a03836/ViT-L-14.pt -d /content/drive/MyDrive/stable-diffusion-webui-colab/stable-diffusion-webui/models/CLIP -o ViT-L-14.pt')

NameError: name 'os' is not defined
```